### PR TITLE
Correction of power level

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -52,8 +52,7 @@ with open('device-template.json') as fp:
 CAPABILITY_TO_META = {
     'powerState': ('onoff', lambda val: 'ON' if val else 'OFF'),
     'brightness': ('dim', lambda val: val),
-    'powerLevel': ('dim',
-        lambda val: {"@type": "IntegralPowerLevel", "value": val}),
+    'powerLevel': ('dim', lambda val: val),
     'percentage': ('dim', lambda val: val),
     'connectivity': ('is_online',
         lambda val: {"value": "OK" if val else "UNREACHABLE"})


### PR DESCRIPTION
Updates the porwer level format. 
Docs are tricky here it looks like powerLevel needs a @type: https://developer.amazon.com/docs/device-apis/alexa-property-schemas.html#powerlevel, but in the example of the *Alexa.PowerLevelController*, it doesnt use it. https://developer.amazon.com/docs/device-apis/alexa-powerlevelcontroller.html
This PR fixed my dev lambda (https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/lourdes-alexa-aquaintance?tab=graph) with the same prod problem.